### PR TITLE
Add initial Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+
+/.pytest_cache/
+/ve/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: true
+language: python
+services: docker
+python: '3.6'
+
+install:
+  - pip install -r requirements-dev.txt
+
+script:
+  - flake8
+  - ./test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+
+COPY nginx/gem_molo_unicore.conf /etc/nginx/conf.d/gem_molo_unicore.conf

--- a/nginx/gem_molo_unicore.conf
+++ b/nginx/gem_molo_unicore.conf
@@ -1,0 +1,14 @@
+# The bare domain (without country code) points at the
+# Indonesian site for some reason.
+server {
+    listen 80;
+    server_name gem.molo.unicore.io;
+    return 301 http://id.heyspringster.com/;
+}
+
+# Redirect all other sites based on their country code
+server {
+    listen 80;
+    server_name ~^(?<countrycode>\w\w)\.gem\.molo\.unicore\.io$;
+    return 301 http://$countrycode.heyspringster.com/;
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+flake8==3.5.0
+seaworthy[pytest]==0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+exclude = ve

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker build -t "praekeltfoundation/gem-molo-unicore-redirect" .
+
+pytest

--- a/tests/test_nginx_redirect.py
+++ b/tests/test_nginx_redirect.py
@@ -1,0 +1,30 @@
+from seaworthy.definitions import ContainerDefinition
+
+
+container = ContainerDefinition(
+    'gem-molo-unicore-redirect',
+    'praekeltfoundation/gem-molo-unicore-redirect',
+    create_kwargs={'ports': {'80/tcp': None}}
+)
+
+fixture = container.pytest_fixture('redirect_container')
+
+
+def test_bare_domain_redirect(redirect_container):
+    redirect = redirect_container.http_client().get(
+        '/',
+        allow_redirects=False,
+        headers={'Host': 'gem.molo.unicore.io'},
+    )
+    assert redirect.status_code == 301
+    assert redirect.headers['Location'] == 'http://id.heyspringster.com/'
+
+
+def test_country_code_redirect(redirect_container):
+    redirect = redirect_container.http_client().get(
+        '/',
+        allow_redirects=False,
+        headers={'Host': 'za.gem.molo.unicore.io'},
+    )
+    assert redirect.status_code == 301
+    assert redirect.headers['Location'] == 'http://za.heyspringster.com/'


### PR DESCRIPTION
This is similar to the Nginx config for the [zathu.com redirect](https://github.com/praekeltfoundation/zathu-redirect).

I'm not sure why Indonesia is served using the base domain but we should maintain that behaviour.